### PR TITLE
Add unverified accounts management to admin page

### DIFF
--- a/sms-frontend/src/app/pages/admin/admin.component.html
+++ b/sms-frontend/src/app/pages/admin/admin.component.html
@@ -1,4 +1,5 @@
 <div class="flex items-center justify-center gap-4">
-  <app-add-course />
-  <app-add-exam />
+  <!-- <app-add-course /> -->
+  <!-- <app-add-exam /> -->
+  <app-unverified-accounts/>
 </div>

--- a/sms-frontend/src/app/pages/admin/admin.component.ts
+++ b/sms-frontend/src/app/pages/admin/admin.component.ts
@@ -5,18 +5,21 @@ import { getCourses } from '../../../store/admin/admin.actions';
 import { Observable, Subscription } from 'rxjs';
 import { selectAdminState } from '../../../store/admin/admin.selector';
 import { AddExamComponent } from './add-exam/add-exam.component';
+import { AdminService } from '../../../services/pages/admin.service';
+import { UnverifiedAccountsComponent } from "./unverified-accounts/unverified-accounts.component";
 
 @Component({
   selector: 'app-admin',
-  imports: [AddCourseComponent, AddExamComponent],
+  imports: [AddCourseComponent, AddExamComponent, UnverifiedAccountsComponent],
   templateUrl: './admin.component.html',
   styleUrl: './admin.component.scss',
 })
 export class AdminComponent implements OnInit {
   private store = inject(Store);
-
+  private srv = inject(AdminService);
   ngOnInit() {
     this.store.dispatch(getCourses());
+    this.srv.getUnverifiedAccounts();
   }
 
   ngOnDestroy() {}

--- a/sms-frontend/src/app/pages/admin/unverified-accounts/unverified-accounts.component.html
+++ b/sms-frontend/src/app/pages/admin/unverified-accounts/unverified-accounts.component.html
@@ -1,0 +1,64 @@
+<div class="mb-4">
+  <p-button
+    type="button"
+    icon="pi pi-chevron-left"
+    (click)="prev()"
+    [disabled]="isFirstPage()"
+    text
+  />
+  <p-button type="button" icon="pi pi-refresh" (click)="reset()" text />
+  <p-button
+    type="button"
+    icon="pi pi-chevron-right"
+    (click)="next()"
+    [disabled]="isLastPage()"
+    text
+  />
+</div>
+<div class="card">
+  <p-table
+    [value]="accounts"
+    [paginator]="true"
+    [rows]="5"
+    [first]="first"
+    [showCurrentPageReport]="true"
+    [tableStyle]="{ 'min-width': '50rem' }"
+    currentPageReportTemplate="Showing {first} to {last} of {totalRecords} entries"
+    (onPage)="pageChange($event)"
+    [rowsPerPageOptions]="[10, 25, 50]"
+  >
+    <ng-template #header>
+      <tr>
+        <th style="width: 25%">Name</th>
+        <th style="width: 25%">Email</th>
+        <th style="width: 25%">Created At</th>
+        <th style="width: 25%">Verfication Status</th>
+      </tr>
+    </ng-template>
+    <ng-template #body let-account>
+      <tr>
+        <td>{{ account.name }}</td>
+        <td>{{ account.email }}</td>
+        <td>{{ account.created_at | date }}</td>
+        <td class="flex gap-2">
+          <p-button
+            label="Approve"
+            (onClick)="approveAcc(account.id)"
+            severity="secondary"
+          />
+          <p-button
+            label="Reject"
+            (onClick)="rejectAcc(account.id)"
+            severity="primary"
+          />
+        </td>
+      </tr>
+    </ng-template>
+    <!-- <ng-template #paginatorleft>
+      <p-button type="button" icon="pi pi-plus" text />
+    </ng-template>
+    <ng-template #paginatorright>
+      <p-button type="button" icon="pi pi-cloud" text />
+    </ng-template> -->
+  </p-table>
+</div>

--- a/sms-frontend/src/app/pages/admin/unverified-accounts/unverified-accounts.component.spec.ts
+++ b/sms-frontend/src/app/pages/admin/unverified-accounts/unverified-accounts.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UnverifiedAccountsComponent } from './unverified-accounts.component';
+
+describe('UnverifiedAccountsComponent', () => {
+  let component: UnverifiedAccountsComponent;
+  let fixture: ComponentFixture<UnverifiedAccountsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UnverifiedAccountsComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(UnverifiedAccountsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/sms-frontend/src/app/pages/admin/unverified-accounts/unverified-accounts.component.ts
+++ b/sms-frontend/src/app/pages/admin/unverified-accounts/unverified-accounts.component.ts
@@ -1,0 +1,73 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { AdminService } from '../../../../services/pages/admin.service';
+import { TableModule } from 'primeng/table';
+import { CommonModule, DatePipe } from '@angular/common';
+import { ButtonModule } from 'primeng/button';
+import { Response } from '../../../models/global.model';
+
+@Component({
+  selector: 'app-unverified-accounts',
+  imports: [TableModule, CommonModule, ButtonModule, DatePipe],
+  templateUrl: './unverified-accounts.component.html',
+  styleUrl: './unverified-accounts.component.scss',
+})
+export class UnverifiedAccountsComponent implements OnInit {
+  private srv = inject(AdminService);
+
+  first = 0;
+  rows = 10;
+  accounts: any = [];
+  ngOnInit() {
+    this.srv.unverifiedAcountsObv.subscribe((data) => {
+      console.log(data);
+      this.accounts = data;
+    });
+  }
+  next() {
+    this.first = this.first + this.rows;
+  }
+
+  prev() {
+    this.first = this.first - this.rows;
+  }
+
+  reset() {
+    this.first = 0;
+  }
+
+  pageChange(event: any) {
+    this.first = event.first;
+    this.rows = event.rows;
+  }
+
+  isLastPage(): boolean {
+    return this.accounts
+      ? this.first + this.rows >= this.accounts.length
+      : true;
+  }
+
+  isFirstPage(): boolean {
+    return this.accounts ? this.first === 0 : true;
+  }
+
+  approveAcc(id: number) {
+    console.log(id);
+    this.srv.updateAccountStatus(id, '1').subscribe((data: Response) => {
+      if (data.code == 200 && data.status == 'success') {
+        this.accounts = this.accounts.filter(
+          (acc: { id: number }) => acc.id != id
+        );
+      }
+    });
+  }
+  rejectAcc(id: number) {
+    console.log(id);
+    this.srv.updateAccountStatus(id, '3').subscribe((data: Response) => {
+      if (data.code == 200 && data.status == 'success') {
+        this.accounts = this.accounts.filter(
+          (acc: { id: number }) => acc.id != id
+        );
+      }
+    });
+  }
+}

--- a/sms-frontend/src/services/pages/admin.service.ts
+++ b/sms-frontend/src/services/pages/admin.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Response } from '../../app/models/global.model';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { Course, CourseExam } from '../../app/models/admin.model';
 
 @Injectable({
@@ -9,6 +9,12 @@ import { Course, CourseExam } from '../../app/models/admin.model';
 })
 export class AdminService {
   private http = inject(HttpClient);
+  private unverifiedAccounts = new BehaviorSubject<any[]>([]);
+  public unverifiedAcountsObv = this.unverifiedAccounts.asObservable();
+
+  setUnverifiedAccounts(data: any) {
+    this.unverifiedAccounts.next(data);
+  }
 
   insertCourse(course: Course): Observable<Response> {
     console.log(course);
@@ -20,10 +26,33 @@ export class AdminService {
   getCourses(): Observable<Response> {
     return this.http.get<Response>('http://localhost:3003/admin/get-courses');
   }
-  insertCourseExam(exam:CourseExam): Observable<Response> {
+
+  insertCourseExam(exam: CourseExam): Observable<Response> {
     return this.http.post<Response>(
       'http://localhost:3003/admin/add-course-exam',
       exam
+    );
+  }
+
+  getUnverifiedAccounts() {
+    this.http
+      .get<Response>('http://localhost:3003/admin/unverified-accounts')
+      .subscribe(
+        (response: Response) => {
+          if (response.code == 200 && response.status == 'success') {
+            this.setUnverifiedAccounts(response.body);
+          }
+        },
+        (err) => {
+          console.log(err);
+        }
+      );
+  }
+
+  updateAccountStatus(id: number, status: string) {
+    return this.http.patch<Response>(
+      `http://localhost:3003/admin/approve-unverified-accounts/${id}/${status}`,
+      ''
     );
   }
 }


### PR DESCRIPTION
Introduce a component for managing unverified accounts and integrate it into the admin page. Update the admin service to handle fetching and updating the status of unverified accounts. admin-1002